### PR TITLE
feat: simplified at_talk code

### DIFF
--- a/bin/at_talk.dart
+++ b/bin/at_talk.dart
@@ -161,7 +161,6 @@ Future<void> atTalk(List<String> args) async {
 
   var lines = stdin.transform(utf8.decoder).transform(const LineSplitter());
 
-  bool firstSend = true;
   int pendingSend = 0;
   await for (final l in lines) {
     input = l;
@@ -188,27 +187,14 @@ Future<void> atTalk(List<String> args) async {
       try {
         pendingSend++;
 
-        if (firstSend) {
-          await notificationService.notify(NotificationParams.forUpdate(key, value: input), onSuccess: (notification) {
-            _logger.info('SUCCESS:' + notification.toString());
-          }, onError: (notification) {
-            _logger.info('ERROR:' + notification.toString());
-          }, onSentToSecondary: (notification) {
-            _logger.info('SENT:' + notification.toString());
-            pendingSend--;
-          });
-
-          firstSend = false;
-        } else {
-          notificationService.notify(NotificationParams.forUpdate(key, value: input), onSuccess: (notification) {
-            _logger.info('SUCCESS:' + notification.toString());
-          }, onError: (notification) {
-            _logger.info('ERROR:' + notification.toString());
-          }, onSentToSecondary: (notification) {
-            _logger.info('SENT:' + notification.toString());
-            pendingSend--;
-          });
-        }
+        await notificationService.notify(NotificationParams.forUpdate(key, value: input), onSuccess: (notification) {
+          _logger.info('SUCCESS:' + notification.toString());
+        }, onError: (notification) {
+          _logger.info('ERROR:' + notification.toString());
+        }, onSentToSecondary: (notification) {
+          _logger.info('SENT:' + notification.toString());
+          pendingSend--;
+        }, checkForFinalDeliveryStatus: false);
       } catch (e) {
         _logger.severe(e.toString());
       }

--- a/bin/at_talk.dart
+++ b/bin/at_talk.dart
@@ -194,7 +194,7 @@ Future<void> atTalk(List<String> args) async {
         }, onSentToSecondary: (notification) {
           _logger.info('SENT:' + notification.toString());
           pendingSend--;
-        }, checkForFinalDeliveryStatus: false);
+        }, waitForFinalDeliveryStatus: false);
       } catch (e) {
         _logger.severe(e.toString());
       }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -21,7 +21,7 @@ packages:
       name: archive
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.3.0"
+    version: "3.3.1"
   args:
     dependency: transitive
     description:
@@ -55,7 +55,7 @@ packages:
     description:
       path: at_client
       ref: RemoveNetworkCheckFrom_AtClientImpl_notify
-      resolved-ref: b62268520ffe4574443389e0f0ae039c07a1b5b5
+      resolved-ref: d66af748d27336512ce3ff63f9a22868cfadbcc6
       url: "https://github.com/atsign-foundation/at_client_sdk.git"
     source: git
     version: "3.0.30"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,6 +7,8 @@ environment:
   sdk: '>=2.17.3 <3.0.0'
 
 dependency_overrides:
+#  at_client:
+#    path: ../at_client_sdk/at_client
   at_client:
     git:
       url: https://github.com/atsign-foundation/at_client_sdk.git


### PR DESCRIPTION
**- What I did**
Made some changes in at_client_sdk branch which enables simplification of the at_talk code. Can call notify with `await` every time now because of the added optional flags `checkForFinalDeliveryStatus` and `waitForFinalDeliveryStatus`. Both default to true; at_talk now sets `waitForFinalDeliveryStatus` to false. To explain a little more:
* Setting `waitForFinalDeliveryStatus` to false, and allowing `checkForFinalDeliveryStatus` to remain true, means that we **will** poll for final delivery status, but we will do so asynchronously - thus, the call to `notify` will return as soon as the notify: command has been sent to our secondary server
* Setting `checkForFinalDeliveryStatus` to false means that we will not automatically start polling for final delivery status. (Of course the polling can be done elsewhere in programme code if required.)

**- Description for the changelog**
feat: simplified at_talk code based on latest at_client_sdk changes