### PR TITLE
chore: Use at instead of @ for consistent lexicon

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@ You need to put your @<your atSign>.atKeys file in ~/.atsign/keys and then run t
 
 e.g.
 
+`dart pub get`
+
+To ensure that dependencies are in place. Then:
+
 `dart bin/at_talk.dart -a "@colin" -t "@kevin"`
 
 The person you want to atTalk with will have to do the same but in reverse

--- a/bin/at_talk.dart
+++ b/bin/at_talk.dart
@@ -8,7 +8,7 @@ import 'package:at_talk/pipe_print.dart';
 import 'package:logging/src/level.dart';
 import 'package:chalkdart/chalk.dart';
 
-// @platform packages
+// atPlatform packages
 import 'package:at_client/at_client.dart';
 import 'package:at_utils/at_logger.dart';
 import 'package:at_onboarding_cli/at_onboarding_cli.dart';
@@ -39,10 +39,10 @@ Future<void> atTalk(List<String> args) async {
   parser.addOption('key-file',
       abbr: 'k',
       mandatory: false,
-      help: 'Your @sign\'s atKeys file if not in ~/.atsign/keys/');
+      help: 'Your atSign\'s atKeys file if not in ~/.atsign/keys/');
   parser.addOption('atsign', abbr: 'a', mandatory: true, help: 'Your atSign');
   parser.addOption('toatsign',
-      abbr: 't', mandatory: true, help: 'Talk to this @sign');
+      abbr: 't', mandatory: true, help: 'Talk to this atSign');
   parser.addOption('root-domain',
       abbr: 'd',
       mandatory: false,
@@ -62,7 +62,7 @@ Future<void> atTalk(List<String> args) async {
   try {
     // Arg check
     results = parser.parse(args);
-    // Find @sign key file
+    // Find atSign key file
     fromAtsign = results['atsign'];
     toAtsign = results['toatsign'];
 
@@ -86,7 +86,7 @@ Future<void> atTalk(List<String> args) async {
     exit(1);
   }
 
-// Now on to the @platform startup
+// Now on to the atPlatform startup
   AtSignLogger.root_level = 'SHOUT';
   if (results['verbose']) {
     _logger.logger.level = Level.INFO;


### PR DESCRIPTION
I was just trying this for myself, and spotted a few things that needed tweaking

**- What I did**

* Section in README to remind people to get dependencies
* Consistent lexicon usage (atStuff rather than @)

**- How to verify it**

Tested locally and seems to be performing as expected (first message problem is still there).

Code changes are in text fields and comments

**- Description for the changelog**

chore: Use at instead of @ for consistent lexicon